### PR TITLE
template support for array item names

### DIFF
--- a/formule-demo/yarn.lock
+++ b/formule-demo/yarn.lock
@@ -443,6 +443,34 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
+"@lezer/common@^1.0.0", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.2.1.tgz#198b278b7869668e1bebbe687586e12a42731049"
+  integrity sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==
+
+"@lezer/highlight@^1.0.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.0.tgz#e5898c3644208b4b589084089dceeea2966f7780"
+  integrity sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.2.tgz#bdc849e174113e2d9a569a5e6fb1a27e2f703eaf"
+  integrity sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.0.tgz#ed52a75dbbfbb0d1eb63710ea84c35ee647cb67e"
+  integrity sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -806,6 +834,11 @@
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.8.tgz#518609aefb797da19bf222feb199e8f653ff7627"
   integrity sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/use-sync-external-store@^0.0.3":
   version "0.0.3"
@@ -1264,6 +1297,11 @@ classnames@2.x, classnames@^2.2.1, classnames@^2.2.3, classnames@^2.2.5, classna
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -1406,6 +1444,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     which "^2.0.1"
 
 csstype@^3.0.2, csstype@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
@@ -1923,6 +1966,11 @@ follow-redirects@^1.15.4:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -2141,6 +2189,16 @@ ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
+
+immer@^9.0.21:
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
+
+immutability-helper@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-3.1.1.tgz#2b86b2286ed3b1241c9e23b7b21e0444f52f77b7"
+  integrity sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==
 
 immer@^9.0.21:
   version "9.0.21"
@@ -3489,6 +3547,11 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -3719,6 +3782,11 @@ typescript@^5.0.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/language": "^6.8.0",
     "@codemirror/legacy-modes": "^6.3.3",
+    "@codemirror/lint": "^6.5.0",
     "@codemirror/merge": "^6.1.1",
     "@reduxjs/toolkit": "^1.9.5",
     "@rjsf/antd": "^5.13.0",

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 export default {
-  branches: ["add-semantic-release"],
+  branches: ["master"],
   plugins: [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/src/admin/utils/fieldTypes.jsx
+++ b/src/admin/utils/fieldTypes.jsx
@@ -195,11 +195,40 @@ const collections = {
     },
     optionsSchemaUiSchema: {},
     optionsUiSchema: {
-      ...common.optionsUiSchema,
+      type: "object",
+      title: "UI Schema",
+      properties: {
+        "ui:options": {
+          type: "object",
+          title: "UI Options",
+          properties: {
+            ...common.optionsUiSchema.properties["ui:options"].properties,
+            itemsDisplayTitle: {
+              type: "string",
+              title: "Items Display Title",
+              description:
+                "You can set a fixed value or you can reference child fields between `{{` and `}}`",
+            },
+          },
+        },
+      },
     },
     optionsUiSchemaUiSchema: {
       ...common.optionsUiSchemaUiSchema,
+      "ui:options": {
+        itemsDisplayTitle: {
+          "ui:widget": "itemsDisplayTitle",
+          "ui:options": {
+            descriptionIsMarkdown: true,
+            showAsModal: true,
+            modal: {
+              buttonInNewLine: true,
+            },
+          },
+        },
+      },
     },
+
     default: {
       schema: {
         type: "array",

--- a/src/forms/templates/ArrayFieldTemplates/LayerArrayFieldTemplate.jsx
+++ b/src/forms/templates/ArrayFieldTemplates/LayerArrayFieldTemplate.jsx
@@ -1,35 +1,44 @@
 import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Button, Col, List, Modal, Row, Typography } from "antd";
-
-import * as Sqrl from "squirrelly";
-
+import { render } from "squirrelly";
 import ArrowUpOutlined from "@ant-design/icons/ArrowUpOutlined";
 import ArrowDownOutlined from "@ant-design/icons/ArrowDownOutlined";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import { isFieldContainsError } from "../utils";
 
-const LayerArrayFieldTemplate = ({ items = [] }) => {
+const LayerArrayFieldTemplate = ({ items = [], uiSchema }) => {
   const [itemToDisplay, setItemToDisplay] = useState(null);
   const [visible, setVisible] = useState(false);
 
+  // FIXME: stringifyTmpl and stringify are deprecated and will be removed in favor of itemsDisplayTitle
   const stringifyItem = (options, item) => {
-    let stringifyTmpl = options ? options.stringifyTmpl : null;
-    if (stringifyTmpl) {
+    const itemsDisplayTitle = uiSchema?.["ui:options"]?.itemsDisplayTitle;
+
+    /**
+     * @deprecated
+     */
+    const stringifyTmpl = options ? options.stringifyTmpl : null;
+    if (itemsDisplayTitle || stringifyTmpl) {
       try {
-        let str = Sqrl.render(stringifyTmpl, item);
+        const str = render(itemsDisplayTitle || stringifyTmpl, item, {
+          useWith: true,
+        });
         return str;
       } catch (_err) {
         return null;
       }
     }
 
+    /**
+     * @deprecated
+     */
     const stringify = options ? options.stringify : [],
       reducer = (acc, val) => (item[val] ? `${acc} ${item[val]}` : acc);
 
     return stringify ? stringify.reduce(reducer, "") : null;
   };
-  
+
   useEffect(() => {
     if (items && itemToDisplay)
       setItemToDisplay({
@@ -140,7 +149,7 @@ const LayerArrayFieldTemplate = ({ items = [] }) => {
                 <Typography.Text ellipsis>
                   {stringifyItem(
                     item?.children?.props?.uiSchema?.["ui:options"] ?? null,
-                    item.children.props.formData
+                    item.children.props.formData,
                   ) || `Item #${item.index + 1}`}
                 </Typography.Text>
               }

--- a/src/forms/templates/ArrayFieldTemplates/NormalArrayFieldTemplate.jsx
+++ b/src/forms/templates/ArrayFieldTemplates/NormalArrayFieldTemplate.jsx
@@ -48,15 +48,15 @@ const NormalArrayFieldTemplate = ({
   const [emailModal, setEmailModal] = useState(false);
   const [selectedEmailList, setSelectedEmailList] = useState(
     uiSchema["ui:options"] && uiSchema["ui:options"].email
-      ? formData.map(user => user?.profile?.email)
-      : []
+      ? formData.map((user) => user?.profile?.email)
+      : [],
   );
   const [copy, setCopy] = useState(false);
   const [importModal, setImportModal] = useState(false);
   const labelClsBasic = `${prefixCls}-item-label`;
   const labelColClassName = classNames(
     labelClsBasic,
-    labelAlign === "left" && `${labelClsBasic}-left`
+    labelAlign === "left" && `${labelClsBasic}-left`,
   );
   const { token } = useToken();
 
@@ -72,14 +72,17 @@ const NormalArrayFieldTemplate = ({
     uiEmailDefaults = uiSchema["ui:options"].emailDefaults || [];
   }
 
-  let typeOfArrayToDisplay = uiSchema && uiSchema.items && uiSchema.items["ui:object"] ? uiSchema.items["ui:object"] : "default";
+  let typeOfArrayToDisplay =
+    uiSchema && uiSchema.items && uiSchema.items["ui:object"]
+      ? uiSchema.items["ui:object"]
+      : "default";
 
-  const getArrayContent = type => {
+  const getArrayContent = (type) => {
     const choices = {
       layerObjectField: (
         <LayerArrayFieldTemplate
           items={items}
-          formContext={formContext}
+          uiSchema={uiSchema}
           id={idSchema.$id}
         />
       ),
@@ -107,7 +110,7 @@ const NormalArrayFieldTemplate = ({
     let { to } = uiImport;
     let data = formData;
 
-    if (type == "object" && to) data = formData.map(item => item[to] || "");
+    if (type == "object" && to) data = formData.map((item) => item[to] || "");
 
     if (!latexData) {
       axios
@@ -127,12 +130,12 @@ const NormalArrayFieldTemplate = ({
     }
   };
 
-  const updateEmailSelectedList = email => {
+  const updateEmailSelectedList = (email) => {
     selectedEmailList.includes(email)
-      ? setSelectedEmailList(selectedEmailList =>
-          selectedEmailList.filter(item => item != email)
+      ? setSelectedEmailList((selectedEmailList) =>
+          selectedEmailList.filter((item) => item != email),
         )
-      : setSelectedEmailList(selectedEmailList => [
+      : setSelectedEmailList((selectedEmailList) => [
           ...selectedEmailList,
           email,
         ]);
@@ -140,12 +143,12 @@ const NormalArrayFieldTemplate = ({
   const updateEmailSelectedListAll = () => {
     formData.length === selectedEmailList.length
       ? setSelectedEmailList([])
-      : setSelectedEmailList(formData.map(user => user?.profile?.email));
+      : setSelectedEmailList(formData.map((user) => user?.profile?.email));
   };
 
   useEffect(() => {
     if (emailModal && formData.length != selectedEmailList.length)
-      setSelectedEmailList(formData.map(user => user?.profile?.email));
+      setSelectedEmailList(formData.map((user) => user?.profile?.email));
   }, [emailModal]);
 
   return (
@@ -162,30 +165,12 @@ const NormalArrayFieldTemplate = ({
             setShowModal(false);
             setLatexData(null);
           }}
-          footer={
-            <Row justify="end">
-              <Space>
-                <Button
-                  onClick={() => {
-                    setShowModal(false);
-                    setLatexData(null);
-                  }}
-                >
-                  Close
-                </Button>
-                <Button
-                  type="primary"
-                  onClick={() => {
-                    navigator.clipboard.writeText(decodeURI(latexData));
-                    setCopy(true);
-                  }}
-                  icon={copy ? <CheckOutlined /> : <CopyOutlined />}
-                >
-                  {copy ? "Copied" : "Copy to clipboard"}
-                </Button>
-              </Space>
-            </Row>
-          }
+          okText={copy ? "Copied" : "Copy to clipboard"}
+          okButtonProps={{ icon: copy ? <CheckOutlined /> : <CopyOutlined /> }}
+          onOk={() => {
+            navigator.clipboard.writeText(decodeURI(latexData));
+            setCopy(true);
+          }}
         >
           <CodeViewer
             value={latexData}
@@ -233,14 +218,14 @@ const NormalArrayFieldTemplate = ({
               <Col>
                 Default email recepients:{" "}
                 <Space>
-                  {uiEmailDefaults.map(i => (
+                  {uiEmailDefaults.map((i) => (
                     <Tag key={i}>{i}</Tag>
                   ))}
                 </Space>
               </Col>
             ) : null}
             <Table
-              dataSource={formData.map(i => i.profile || i)}
+              dataSource={formData.map((i) => i.profile || i)}
               columns={[
                 {
                   title: "Email User",
@@ -261,13 +246,13 @@ const NormalArrayFieldTemplate = ({
                   title: "Email",
                   dataIndex: "email",
                   key: "email",
-                  render: txt => <Tag color="geekblue">{txt}</Tag>,
+                  render: (txt) => <Tag color="geekblue">{txt}</Tag>,
                 },
                 {
                   title: "Department",
                   dataIndex: "department",
                   key: "department",
-                  render: txt => <Tag color="blue">{txt}</Tag>,
+                  render: (txt) => <Tag color="blue">{txt}</Tag>,
                 },
               ]}
             />

--- a/src/forms/widgets/ItemsDisplayTitle.jsx
+++ b/src/forms/widgets/ItemsDisplayTitle.jsx
@@ -1,0 +1,25 @@
+import { StreamLanguage } from "@codemirror/language";
+import CodeEditor from "../../utils/CodeEditor";
+import { jinja2 } from "@codemirror/legacy-modes/mode/jinja2";
+import { placeholder } from "@codemirror/view";
+
+// TODO: Remove this component once https://github.com/cern-sis/react-formule/issues/21
+// is implemented and use that general CodeEditor directly from fieldTypes.jsx
+const ItemsDisplayTitle = ({ onChange, value }) => {
+  return (
+    <div style={{ height: "200px" }}>
+      <CodeEditor
+        height="100%"
+        value={value}
+        handleEdit={() => onChange(value)}
+        extraExtensions={[
+          StreamLanguage.define(jinja2),
+          placeholder("Path: {{item_123}} - Type: {{item_456}}"),
+        ]}
+        minimal
+      />
+    </div>
+  );
+};
+
+export default ItemsDisplayTitle;

--- a/src/forms/widgets/index.js
+++ b/src/forms/widgets/index.js
@@ -6,6 +6,7 @@ import UriWidget from "./UriWidget";
 import DateWidget from "./DateWidget";
 import RequiredWidget from "./RequiredWidget";
 import SelectWidget from "./SelectWidget";
+import ItemsDisplayTitle from "./ItemsDisplayTitle";
 
 const widgets = {
   text: TextWidget,
@@ -17,6 +18,7 @@ const widgets = {
   checkbox: CheckboxWidget,
   date: DateWidget,
   select: SelectWidget,
+  itemsDisplayTitle: ItemsDisplayTitle,
 };
 
 export default widgets;

--- a/src/utils/CodeEditor.jsx
+++ b/src/utils/CodeEditor.jsx
@@ -1,0 +1,44 @@
+import { EditorView, keymap } from "@codemirror/view";
+import { linter, lintGutter } from "@codemirror/lint";
+import { indentWithTab } from "@codemirror/commands";
+import CodeViewer from "./CodeViewer";
+
+const CodeEditor = ({
+  value,
+  lang,
+  lint,
+  isReadOnly = false,
+  handleEdit,
+  schema,
+  height,
+  extraExtensions,
+  reset,
+  minimal,
+}) => {
+  const editorExtensions = [
+    keymap.of([indentWithTab]),
+    lint ? [linter(lint()), lintGutter()] : [],
+    EditorView.updateListener.of((update) => {
+      if (update.docChanged) {
+        handleEdit(update.state.doc.toString());
+      }
+    }),
+    ...extraExtensions,
+  ];
+
+  return (
+    <CodeViewer
+      value={value}
+      lang={lang}
+      isReadOnly={isReadOnly}
+      extraExtensions={editorExtensions}
+      schema={schema}
+      height={height}
+      listener={handleEdit}
+      reset={reset}
+      minimal={minimal}
+    />
+  );
+};
+
+export default CodeEditor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,15 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
+"@codemirror/lint@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.5.0.tgz#ea43b6e653dcc5bcd93456b55e9fe62e63f326d9"
+  integrity sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
 "@codemirror/merge@^6.1.1":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@codemirror/merge/-/merge-6.6.0.tgz#da380a1ce14f4cd54b71f233deefdd94bc1bc839"


### PR DESCRIPTION
Closes #24 

- `stringify` and `stringifyTmpl` in children `item.children.props.uiSchema["ui:options"]` have been deprecated in favor of `itemsDisplayTitle` in `uiOptions` in the list component. We should remove them completely once @pamfilos takes care of the backend and existing schemas in CAP.
- Moved codemirror editor to formule and refactored it to work with our new use case and to follow the app styling. I have not yet removed codemirror from CAP, but it could be done anytime and it should work right away (we just need to export the viewer and editor from formule and import them in CAP, to be done in another task)
- `itemsDisplayTitle` can be set in a codemirror editor which has jinja syntax highlighting
- Added `useWith: true` to squirrelly's render method to be able to use `{{asd}}` in templates instead of having to prefix it with `it.` (`{{it.asd}}`)