### PR TITLE
ci(publish): add gh_token to publish step instead of to checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          token: ${{ secrets.GH_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -33,6 +32,7 @@ jobs:
 
       - name: Publish
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.CERN_SIS_NPM }}
         run: HUSKY=0 npx semantic-release ${{ inputs.semanticReleaseParams }}


### PR DESCRIPTION
Fix for #69 