### PR TITLE
ci(publish): use cern-sis-bot for semantic-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Publish
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CERN_SIS_BOT }}
           NPM_TOKEN: ${{ secrets.CERN_SIS_NPM }}
         run: HUSKY=0 npx semantic-release ${{ inputs.semanticReleaseParams }}


### PR DESCRIPTION
Closes #73 