### PR TITLE
feat(form): add (auto)save and local schema repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Formule consists of the following main components:
 
 It also exports the following functions:
 
-- **`initFormuleSchema`**: Inits the JSONSchema, **_needs_** to be run on startup.
+- **`initFormuleSchema`**: Inits or resets the JSONSchema. You can also load an existing schema by passing it as an argument.
 - **`getFormuleState`**: Formule has its own internal redux state. You can retrieve it at any moment if you so require for more advanced use cases. If you want to continuosly synchronize the Formule state in your app, you can pass a callback function to FormuleContext instead (see below), which will be called every time the form state changes.
 
 And the following utilities:
@@ -51,6 +51,16 @@ And the following utilities:
 - **`CodeEditor`**: Useful if you want to edit the JSON schemas (or any other code) manually.
 - **`CodeViewer`**: Useful if you want to visualize the JSON schemas that are being generated (as you can see in the demo).
 - **`CodeDiffViewer`**: Useful if you want to compare two different JSON schemas, for example to see the changes since the last save.
+
+As well as the following utility functions to handle saving and loading schemas from local storage if you need and for unsaved change detection:
+
+- `getAllFromLocalStorage`
+- `saveToLocalStorage`
+- `deleteFromLocalStorage`
+- `loadFromLocalStorage`
+- `isUnsaved`
+
+Have a look at `src/index.ts` to see all exported components and functions. You can also have a look at `formule-demo` to see how they are used there.
 
 ### Field types
 
@@ -83,20 +93,19 @@ yarn add react-formule
 
 ```jsx
 import {
-    FormuleContext,
-    SelectOrEdit,
-    SchemaPreview,
-    FormPreview,
-    initFormuleSchema
+  FormuleContext,
+  SelectOrEdit,
+  SchemaPreview,
+  FormPreview,
 } from "react-formule";
 
-const useEffect(() => initFormuleSchema(), []);
-
-<FormuleContext>
+return (
+  <FormuleContext>
     <SelectOrEdit />
     <SchemaPreview />
     <FormPreview />
-</FormuleContext>
+  </FormuleContext>
+);
 ```
 
 ### Customizing and adding new field types
@@ -168,8 +177,8 @@ const handleFormuleStateChange = (newState) => {
 Alternatively, you can pull the current state on demand by calling `getFormuleState` at any moment.
 
 > [!TIP]
-> For more examples, feel free to browse around the [CERN Analysis Preservation](https://github.com/cernanalysispreservation/analysispreservation.cern.ch) repository, where we use all the features mentioned above.
+> For more examples, feel free to browse around formule-demo and the [CERN Analysis Preservation](https://github.com/cernanalysispreservation/analysispreservation.cern.ch) repository, where we use all the features mentioned above.
 
 ## :space_invader: Local demo & how to contribute
 
-Apart from trying the online [demo](https://cern-sis.github.io/react-formule/) you can clone the repo and run `formule-demo` to play around. Follow the instructions in its [README](./formule-demo/README.md): it will explain how to install `react-formule` as a local dependency so that you can modify Formule and test the changes live in your host app, which will be ideal if you want to troubleshoot or contribute to the project.
+Apart from trying the online [demo](https://cern-sis.github.io/react-formule/) you can clone the repo and run `formule-demo` to play around. Follow the instructions in its [README](./formule-demo/README.md): it will explain how to install `react-formule` as a local dependency so that you can modify Formule and test the changes live in your host app, which will be ideal if you want to troubleshoot or contribute to the project. Your contributions are welcome! :rocket:

--- a/formule-demo/README.md
+++ b/formule-demo/README.md
@@ -6,7 +6,7 @@ This is a small application that serves as a playground to test react-formule.
 
 ### The easy way
 
-Simply run `yarn install` and `yarn dev` in react-formule and visit `localhost:3030`. You will see any changes in react-formule immediately in the demo app.
+Simply run `yarn install` in react-formule, `yarn install` and `yarn dev` in formule-demo and visit `localhost:3030`. You will see any changes in react-formule immediately in the demo app.
 
 **Note:** If you look at `formule-demo/vite.config.local.ts` you will see an alias for `react-formule`. What this does is essentially equivalent to using `yarn link` with `./src/index.ts` as entry point.
 

--- a/formule-demo/cypress/e2e/builder.cy.ts
+++ b/formule-demo/cypress/e2e/builder.cy.ts
@@ -5,6 +5,8 @@ const SEP = "\\:\\:";
 describe("test basic functionality", () => {
   beforeEach(() => {
     cy.visit("localhost:3030");
+    // Collapse the float buttons to avoid visibility issues
+    cy.getByDataCy("floatButtons").click();
   });
 
   it("allows drag and drop to the SchemaTree", () => {

--- a/formule-demo/src/App.tsx
+++ b/formule-demo/src/App.tsx
@@ -1,5 +1,32 @@
-import { FileTextOutlined } from "@ant-design/icons";
-import { Col, FloatButton, Layout, Modal, Row, Space, Typography } from "antd";
+import {
+  FileTextOutlined,
+  FolderOpenOutlined,
+  DeleteOutlined,
+  SaveOutlined,
+  FileAddOutlined,
+  CheckOutlined,
+  InfoCircleOutlined,
+  DownloadOutlined,
+  UploadOutlined,
+  RollbackOutlined,
+  ToolOutlined,
+} from "@ant-design/icons";
+import {
+  Button,
+  Col,
+  Drawer,
+  FloatButton,
+  Layout,
+  List,
+  message,
+  Modal,
+  Popconfirm,
+  Row,
+  Space,
+  Tooltip,
+  Typography,
+  Upload,
+} from "antd";
 import { useEffect, useState } from "react";
 import {
   CodeViewer,
@@ -8,7 +35,12 @@ import {
   SchemaPreview,
   SchemaWizardState,
   SelectOrEdit,
+  deleteFromLocalStorage,
+  getAllFromLocalStorage,
   initFormuleSchema,
+  isUnsaved,
+  saveToLocalStorage,
+  loadFromLocalStorage,
 } from "react-formule";
 import { theme } from "./theme";
 
@@ -17,23 +49,70 @@ import "./style.css";
 const { Content, Footer } = Layout;
 
 function App() {
-  useEffect(() => {
-    initFormuleSchema();
-  }, []);
-
   const [formuleState, setFormuleState] = useState<SchemaWizardState>();
-  const [modalOpen, setModalOpen] = useState(false);
+  const [localSchemas, setLocalSchemas] = useState(getAllFromLocalStorage());
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [listOpen, setListOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [justSaved, setJustSaved] = useState(false);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [openFloatButtons, setOpenFloatButtons] = useState(true);
+
+  useEffect(() => {
+    setHasUnsavedChanges(isUnsaved());
+  }, [formuleState]);
+
+  useEffect(() => {
+    const handleKeyDowEvent = (e: KeyboardEvent) => {
+      if (e.ctrlKey || (e.metaKey && e.key === "s")) {
+        e.preventDefault();
+        saveLocalSchema();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDowEvent);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDowEvent);
+    };
+  }, []);
 
   const handleFormuleStateChange = (newState: SchemaWizardState) => {
     setFormuleState(newState);
+  };
+
+  const handleDownload = (id: string, schema: object) => {
+    const a = document.createElement("a");
+    const file = new Blob([JSON.stringify(schema, null, 4)], {
+      type: "text/json",
+    });
+    a.href = URL.createObjectURL(file);
+    a.download = `formuleForm_${id}.json`;
+    a.click();
+  };
+
+  const deleteLocalSchema = (id: string) => {
+    deleteFromLocalStorage(id).then((list) => setLocalSchemas(list));
+    if (id === formuleState?.id) {
+      initFormuleSchema();
+    }
+  };
+
+  const saveLocalSchema = () => {
+    saveToLocalStorage().then((list) => {
+      setHasUnsavedChanges(isUnsaved());
+      setLocalSchemas(list);
+      setJustSaved(true);
+      setTimeout(() => {
+        setJustSaved(false);
+      }, 500);
+    });
   };
 
   return (
     <>
       <Modal
         title="Generated JSON schemas"
-        open={modalOpen}
-        onCancel={() => setModalOpen(false)}
+        open={viewerOpen}
+        onCancel={() => setViewerOpen(false)}
         width={1000}
         footer={null}
       >
@@ -85,6 +164,159 @@ function App() {
           </Col>
         </Row>
       </Modal>
+      <Modal
+        title="Information"
+        open={helpOpen}
+        onCancel={() => setHelpOpen(false)}
+        width={500}
+        footer={null}
+      >
+        <Typography.Paragraph>
+          The state of the current form is <mark>saved automatically</mark> on
+          change. However, this should simply be taken as a security measure to
+          prevent your from accidentally losing data, as changes are not
+          autosaved into your local schemas repository.
+        </Typography.Paragraph>
+        <Typography.Paragraph>
+          If you want to persist the local changes to your schema in your local
+          repository (local storage) you can{" "}
+          <mark>click on the save button or press [ctrl+s]</mark> (your saved
+          schema won't be updated with the latest changes until you do this).
+          You can switch between schemas and load them later on. You can tell
+          when you have unsaved changes by looking at the <mark>blue dot</mark>{" "}
+          on the save button. You can also revert unsaved changes by clicking on
+          the corresponding button.
+        </Typography.Paragraph>
+        <Typography.Paragraph>
+          You are encouraged to <mark>download</mark> any important data as a
+          JSON file for more safety in case your browser's storage gets wiped.
+          You can do so from the "Saved Schemas" drawer.
+        </Typography.Paragraph>
+        <Typography.Paragraph>
+          Additionally, you can also <mark>upload</mark> schemas from a JSON
+          file in the same drawer.
+        </Typography.Paragraph>
+      </Modal>
+      <Drawer
+        title="Saved schemas"
+        open={listOpen}
+        onClose={() => setListOpen(false)}
+        width={600}
+        footer={
+          <Typography.Text type="secondary">
+            The schemas displayed here are stored in your browser's local
+            storage. They are preserved between sessions unless you wipe your
+            browser's storage. Please <b>download</b> your schemas if you don't
+            want to risk losing them.
+          </Typography.Text>
+        }
+        placement="left"
+        extra={
+          <Space>
+            <Tooltip title="Upload schema">
+              <Upload
+                showUploadList={false}
+                beforeUpload={(file) => {
+                  if (file.type != "application/json") {
+                    message.error("The file format should be json");
+                  }
+                  const reader = new FileReader();
+                  reader.onload = (event) => {
+                    const newSchema = JSON.parse(
+                      event?.target?.result as string,
+                    );
+                    const { schema, uiSchema } = newSchema;
+                    if (schema && uiSchema) {
+                      initFormuleSchema(newSchema);
+                      saveLocalSchema();
+                      message.success("Uploaded and loaded successfully");
+                    } else {
+                      message.error(
+                        "Your json should include a schema and a uiSchema key",
+                      );
+                    }
+                  };
+                  reader.readAsText(file);
+                  // Prevent POST upload
+                  return false;
+                }}
+              >
+                <Button icon={<UploadOutlined />} />
+              </Upload>
+            </Tooltip>
+            {localSchemas.length > 0 && (
+              <Popconfirm
+                title="Are you sure?"
+                okType="danger"
+                placement="right"
+                onConfirm={() =>
+                  localSchemas.map((s) => deleteLocalSchema(s.id))
+                }
+              >
+                <Button danger icon={<DeleteOutlined />}>
+                  Delete all
+                </Button>
+              </Popconfirm>
+            )}
+          </Space>
+        }
+      >
+        <div style={{ marginBottom: 12 }}>
+          <Typography.Text>
+            Make sure you have <b>saved</b> your progress in the current schema
+            before switching to another one!
+          </Typography.Text>
+        </div>
+        <List
+          dataSource={localSchemas}
+          renderItem={(item) => (
+            <List.Item
+              actions={[
+                <Popconfirm
+                  title={
+                    <Typography.Paragraph>
+                      Delete schema permanently?
+                    </Typography.Paragraph>
+                  }
+                  okType="danger"
+                  placement="right"
+                  onConfirm={() => deleteLocalSchema(item.id)}
+                >
+                  <Button danger type="text" icon={<DeleteOutlined />} />
+                </Popconfirm>,
+                <Tooltip title="Download schema">
+                  <Button
+                    type="text"
+                    onClick={() => handleDownload(item.id, item.value)}
+                    icon={<DownloadOutlined />}
+                  />
+                </Tooltip>,
+                <Button
+                  type="primary"
+                  ghost
+                  icon={<FolderOpenOutlined />}
+                  onClick={() => {
+                    loadFromLocalStorage(item.id);
+                    setListOpen(false);
+                  }}
+                >
+                  Load
+                </Button>,
+              ]}
+            >
+              <List.Item.Meta
+                title={item.value.schema.title}
+                description={item.value.schema.description}
+              />
+              <div>
+                <Typography.Text type="secondary">
+                  {item.value.id}
+                </Typography.Text>
+              </div>
+            </List.Item>
+          )}
+        />
+      </Drawer>
       <Layout style={{ height: "100%" }}>
         <Content style={{ overflowY: "scroll" }}>
           <FormuleContext
@@ -112,7 +344,7 @@ function App() {
                   backgroundColor: "#F6F7F8",
                 }}
               >
-                <SchemaPreview />
+                <SchemaPreview hideSchemaKey={false} />
               </Col>
               <Col
                 xs={24}
@@ -142,17 +374,102 @@ function App() {
           </Row>
         </Footer>
       </Layout>
-      <FloatButton
-        onClick={() => setModalOpen(true)}
-        shape="square"
-        description={
-          <div>
-            <FileTextOutlined /> View generated schemas
-          </div>
-        }
-        style={{ width: "200px" }}
-        type="primary"
-      />
+      <Tooltip
+        title="Unsaved changes"
+        placement="right"
+        open={!openFloatButtons && hasUnsavedChanges}
+      >
+        <FloatButton.Group
+          shape="square"
+          style={{ insetInlineStart: 16 }}
+          trigger="click"
+          open={openFloatButtons}
+          onClick={() => setOpenFloatButtons(!openFloatButtons)}
+          icon={<ToolOutlined />}
+          type="primary"
+          badge={
+            !openFloatButtons && hasUnsavedChanges
+              ? {
+                  dot: true,
+                  color: "firebrick",
+                }
+              : undefined
+          }
+          data-cy="floatButtons"
+        >
+          {hasUnsavedChanges &&
+            localSchemas.some((s) => s.id === formuleState?.id) && (
+              <Popconfirm
+                title={
+                  <Typography.Paragraph>
+                    Revert and discard the current changes?
+                  </Typography.Paragraph>
+                }
+                okType="danger"
+                placement="right"
+                onConfirm={() => {
+                  loadFromLocalStorage(formuleState?.id ?? "");
+                }}
+              >
+                <FloatButton
+                  icon={<RollbackOutlined />}
+                  tooltip="Revert changes (reload save)"
+                />
+              </Popconfirm>
+            )}
+          <Popconfirm
+            title={
+              <Typography.Paragraph>
+                You will lose the current changes
+              </Typography.Paragraph>
+            }
+            okType="danger"
+            placement="right"
+            onConfirm={() => initFormuleSchema()}
+          >
+            <FloatButton icon={<FileAddOutlined />} tooltip="New schema" />
+          </Popconfirm>
+          <FloatButton
+            onClick={() => saveLocalSchema()}
+            icon={justSaved ? <CheckOutlined /> : <SaveOutlined />}
+            style={
+              justSaved
+                ? { backgroundColor: theme.token.colorPrimary }
+                : undefined
+            }
+            badge={
+              hasUnsavedChanges
+                ? {
+                    dot: true,
+                    color: theme.token.colorPrimary,
+                  }
+                : undefined
+            }
+            tooltip="Save schema to local repository [ctrl+s]"
+          />
+          <FloatButton
+            onClick={() => setListOpen(true)}
+            icon={<FolderOpenOutlined />}
+            badge={{
+              count: localSchemas.length,
+              style: { borderRadius: theme.token.borderRadius },
+              color: theme.token.colorPrimary,
+              size: "small",
+            }}
+            tooltip="Load schema from local repository"
+          />
+          <FloatButton
+            onClick={() => setViewerOpen(true)}
+            icon={<FileTextOutlined />}
+            tooltip="View generated schemas"
+          />
+          <FloatButton
+            onClick={() => setHelpOpen(true)}
+            icon={<InfoCircleOutlined />}
+            tooltip="Information"
+          />
+        </FloatButton.Group>
+      </Tooltip>
     </>
   );
 }

--- a/src/admin/components/SchemaPreview.jsx
+++ b/src/admin/components/SchemaPreview.jsx
@@ -5,11 +5,11 @@ import { SettingOutlined } from "@ant-design/icons";
 import { useDispatch, useSelector } from "react-redux";
 import { selectProperty } from "../../store/schemaWizard";
 
-const SchemaPreview = () => {
+const SchemaPreview = ({ hideSchemaKey }) => {
+  const schema = useSelector((state) => state.schemaWizard.current.schema);
+  const id = useSelector((state) => state.schemaWizard.id);
 
-  const schema = useSelector((state) => state.schemaWizard.current.schema)
-
-  const dispatch = useDispatch()
+  const dispatch = useDispatch();
 
   return (
     <div style={{ height: "80%" }} data-cy="schemaTree">
@@ -17,11 +17,17 @@ const SchemaPreview = () => {
         <Col span={24}>
           <Typography.Title
             level={4}
-            style={{ textAlign: "center", margin: "15px 0" }}
+            style={{
+              textAlign: "center",
+              margin: hideSchemaKey ? "15px 0" : "15px 0 0 0",
+            }}
           >
             Schema tree
           </Typography.Title>
         </Col>
+        {!hideSchemaKey && (
+          <Typography.Text type="secondary">{id}</Typography.Text>
+        )}
       </Row>
       <Row
         wrap={false}
@@ -29,18 +35,25 @@ const SchemaPreview = () => {
         align="middle"
         style={{ padding: "0 10px" }}
       >
-        <Typography.Title level={5} style={{ margin: 0 }} ellipsis data-cy="rootTitle">
+        <Typography.Title
+          level={5}
+          style={{ margin: 0 }}
+          ellipsis
+          data-cy="rootTitle"
+        >
           {(schema && schema.title) || "root"}
         </Typography.Title>
         <Tooltip title="Edit root settings">
-        <Button
-          type="link"
-          shape="circle"
-          icon={<SettingOutlined />}
-          onClick={() => dispatch(selectProperty({ path: { schema: [], uiSchema: [] }}))}
-          className="tour-root-settings"
-          data-cy="rootSettings"
-        />
+          <Button
+            type="link"
+            shape="circle"
+            icon={<SettingOutlined />}
+            onClick={() =>
+              dispatch(selectProperty({ path: { schema: [], uiSchema: [] } }))
+            }
+            className="tour-root-settings"
+            data-cy="rootSettings"
+          />
         </Tooltip>
       </Row>
       <Row style={{ padding: "0 10px" }}>

--- a/src/admin/components/SchemaWizard.jsx
+++ b/src/admin/components/SchemaWizard.jsx
@@ -1,7 +1,7 @@
 import { MultiBackend } from "react-dnd-multi-backend";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
 import { DndProvider } from "react-dnd";
-import { Col, Row, Spin } from "antd";
+import { Col, Row } from "antd";
 import PropertyEditor from "../components/PropertyEditor";
 import SelectFieldType from "../components/SelectFieldType";
 import SchemaPreview from "../components/SchemaPreview";
@@ -13,20 +13,12 @@ import { isEmpty } from "lodash-es";
 
 const SchemaWizard = () => {
   const field = useSelector((state) => state.schemaWizard.field);
-  const loader = useSelector((state) => state.schemaWizard.loader);
 
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(schemaInit());
   }, []);
-
-  if (loader)
-    return (
-      <Row style={{ height: "100%" }} align="middle" justify="center">
-        <Spin size="large" />
-      </Row>
-    );
 
   return (
     <DndProvider backend={MultiBackend} options={HTML5toTouch} context={window}>

--- a/src/admin/utils/index.js
+++ b/src/admin/utils/index.js
@@ -6,16 +6,6 @@ export const SIZE_OPTIONS = {
   xlarge: 24,
 };
 
-export const initSchemaStructure = (name = "New schema", description = "") => ({
-  schema: {
-    title: name,
-    description: description,
-    type: "object",
-    properties: {},
-  },
-  uiSchema: {},
-});
-
 let _addErrors = (errors, path) => {
   errors.addError({ schema: path.schema, uiSchema: path.uiSchema });
 

--- a/src/exposed.tsx
+++ b/src/exposed.tsx
@@ -1,16 +1,22 @@
 import { DndProvider } from "react-dnd";
 import { MultiBackend } from "react-dnd-multi-backend";
 import { HTML5toTouch } from "rdndmb-html5-to-touch";
-import { initSchemaStructure, combineFieldTypes } from "./admin/utils";
+import { combineFieldTypes } from "./admin/utils";
 import CustomizationContext from "./contexts/CustomizationContext";
 import { ConfigProvider, ThemeConfig } from "antd";
 import { Provider } from "react-redux";
 import store from "./store/configureStore";
 import fieldTypes from "./admin/utils/fieldTypes";
-import { ReactNode } from "react";
+import { ReactNode, SetStateAction } from "react";
 import { RJSFSchema } from "@rjsf/utils";
-import { SchemaWizardState, schemaInit } from "./store/schemaWizard";
+import {
+  SchemaWizardState,
+  initialState,
+  schemaInit,
+} from "./store/schemaWizard";
 import StateSynchronizer from "./StateSynchronizer";
+import { isEqual, pick } from "lodash-es";
+import { itemIdGenerator } from "./utils";
 
 type FormuleContextProps = {
   children: ReactNode;
@@ -24,6 +30,8 @@ type FormuleContextProps = {
   synchronizeState?: (state: SchemaWizardState) => void;
   transformSchema?: (schema: object) => object;
 };
+
+const LOCAL_STORAGE_KEY = "formuleForm_";
 
 export const FormuleContext = ({
   children,
@@ -73,24 +81,94 @@ export const FormuleContext = ({
   );
 };
 
-// TODO: Review typing (here and in the actions file)
 export const initFormuleSchema = (
   data?: RJSFSchema,
-  name?: string,
+  title?: string,
   description?: string,
 ) => {
-  const { deposit_schema, deposit_options, ...configs } = data || {};
+  const { schema, uiSchema, id } = data || {};
   store.dispatch(
     schemaInit({
-      data:
-        deposit_schema && deposit_options
-          ? { schema: deposit_schema, uiSchema: deposit_options }
-          : initSchemaStructure(name, description),
-      configs: configs || { fullname: name },
+      data: {
+        schema: schema || {
+          ...initialState.current.schema,
+          ...(title && { title }),
+          ...(description && { description }),
+        },
+        uiSchema: uiSchema || initialState.current.uiSchema,
+      },
+      id: id || itemIdGenerator(),
     }),
   );
 };
 
 export const getFormuleState = () => {
   return store.getState().schemaWizard;
+};
+
+export const getAllFromLocalStorage = () => {
+  return Object.entries(localStorage)
+    .filter(([k, v]) => {
+      if (k.startsWith(LOCAL_STORAGE_KEY)) {
+        try {
+          JSON.parse(v);
+          return true;
+        } catch (error) {
+          console.error("Error parsing formuleForm JSON: ", error);
+          return false;
+        }
+      }
+      return false;
+    })
+    .map(([k, v]) => ({ id: k.split("_")[1], value: JSON.parse(v) }));
+};
+
+const handleStorageEvent = (resolve) => {
+  resolve(getAllFromLocalStorage());
+  window.removeEventListener("storage", handleStorageEvent);
+};
+
+const storagePromise = (func) => {
+  return new Promise<SetStateAction<{ id: string; value: object }[]>>(
+    (resolve) => {
+      window.addEventListener("storage", () => handleStorageEvent(resolve));
+      func();
+      window.dispatchEvent(new Event("storage"));
+    },
+  );
+};
+
+export const saveToLocalStorage = () => {
+  return storagePromise(() => {
+    const formuleState = store.getState().schemaWizard;
+    const localStorageKey = `${LOCAL_STORAGE_KEY}${formuleState.id}`;
+    localStorage.setItem(
+      localStorageKey,
+      JSON.stringify({ ...formuleState.current, id: formuleState.id }),
+    );
+  });
+};
+
+export const deleteFromLocalStorage = (id: string) => {
+  return storagePromise(() =>
+    localStorage.removeItem(`${LOCAL_STORAGE_KEY}${id}`),
+  );
+};
+
+export const loadFromLocalStorage = (id: string) => {
+  const localState = JSON.parse(
+    localStorage.getItem(`${LOCAL_STORAGE_KEY}${id}`) || "{}",
+  );
+  initFormuleSchema(localState);
+};
+
+export const isUnsaved = () => {
+  const formuleState = store.getState().schemaWizard;
+  const localState = JSON.parse(
+    localStorage.getItem(`${LOCAL_STORAGE_KEY}${formuleState.id}`) ?? "{}",
+  );
+  return !isEqual(
+    formuleState.current,
+    pick(localState, ["schema", "uiSchema"]),
+  );
 };

--- a/src/forms/Form.jsx
+++ b/src/forms/Form.jsx
@@ -114,7 +114,6 @@ RJSFForm.propTypes = {
   formContext: PropTypes.object,
   widgets: PropTypes.object,
   mode: PropTypes.string,
-  draftEditor: PropTypes.bool,
   readonly: PropTypes.bool,
   className: PropTypes.string,
   liveValidate: PropTypes.bool,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 export { initFormuleSchema } from "./exposed";
 export { getFormuleState } from "./exposed";
 export { FormuleContext } from "./exposed";
+export { getAllFromLocalStorage } from "./exposed";
+export { saveToLocalStorage } from "./exposed";
+export { deleteFromLocalStorage } from "./exposed";
+export { loadFromLocalStorage } from "./exposed";
+export { isUnsaved } from "./exposed";
 
 export { default as PropertyEditor } from "./admin/components/PropertyEditor";
 export { default as SelectFieldType } from "./admin/components/SelectFieldType";

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,10 +1,31 @@
-import schemaWizard from "./schemaWizard";
+import schemaWizard, { initialState } from "./schemaWizard";
 import { configureStore } from "@reduxjs/toolkit";
+
+const preloadedState = () => {
+  let parsedData;
+  try {
+    parsedData = JSON.parse(localStorage.getItem("formuleCurrent"));
+  } catch (error) {
+    console.error("Error parsing formuleCurrent from localStorage: ", error);
+  }
+  return parsedData || { schemaWizard: initialState };
+};
+
+export const persistMiddleware = ({ getState }) => {
+  return (next) => (action) => {
+    const result = next(action);
+    localStorage.setItem("formuleCurrent", JSON.stringify(getState()));
+    return result;
+  };
+};
 
 const store = configureStore({
   reducer: {
     schemaWizard,
   },
+  preloadedState: preloadedState(),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(persistMiddleware),
 });
 
 export default store;

--- a/src/store/schemaWizard.ts
+++ b/src/store/schemaWizard.ts
@@ -1,26 +1,26 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { notification } from "antd";
 import { set, get } from "lodash-es";
-import { findParentPath } from "../utils";
+import { findParentPath, itemIdGenerator } from "../utils";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
-const initialState = {
+export const initialState = {
   current: {
-    schema: {},
+    schema: {
+      title: "New schema",
+      description: "",
+      type: "object",
+      properties: {},
+    },
     uiSchema: {},
   },
   initial: {
     schema: {},
     uiSchema: {},
   },
-  initialConfig: {},
-  config: {},
+  id: itemIdGenerator(),
   field: {},
   formData: {},
-  propKeyEditor: null,
-  error: null,
-  loader: false,
-  version: null,
 };
 
 export type SchemaWizardState = typeof initialState;
@@ -29,14 +29,12 @@ const schemaWizard = createSlice({
   name: "schemaWizard",
   initialState,
   reducers: {
-    schemaInit(state, action: PayloadAction<{ data; configs }>) {
-      const { data, configs } = action.payload;
+    schemaInit(state, action: PayloadAction<{ data; id }>) {
+      const { data, id } = action.payload;
+      Object.assign(state, initialState);
       state["current"] = data;
       state["initial"] = data;
-      state["config"] = configs;
-      state["version"] = configs.version;
-      state["initialConfig"] = configs;
-      state["loader"] = false;
+      state["id"] = id;
     },
     enableCreateMode(state) {
       state["field"] = {};
@@ -69,7 +67,7 @@ const schemaWizard = createSlice({
       let _path = schemaPath;
       let _uiPath = uiSchemaPath;
 
-      const random_name = `item_${Math.random().toString(36).substring(2, 8)}`;
+      const random_name = `item_${itemIdGenerator()}`;
 
       if (schema.type) {
         if (schema.type == "object") {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -41,3 +41,5 @@ export const findParentPath = (schemaPath) => {
   }
   return [];
 };
+
+export const itemIdGenerator = () => Math.random().toString(36).substring(2, 8);


### PR DESCRIPTION
Closes #84
Related https://github.com/cernanalysispreservation/analysispreservation.cern.ch/issues/2897

- Adds an autosave feature (into localStorage as `formuleCurrent`). When reloading the page or closing and opening the browser the last state will be loaded automatically
- Adds the following features in a floating menu in formule-demo:
  - Manual save: with a ctrl+s shortcut as well (into localStorage as `formuleForm_<formid>`). It shows a badge when there are unsaved changes
  - Load schemas: new drawer listing all the schemas currently stored in localStorage, lets you delete, download and upload schemas
  - Revert: reverts unsaved changes
  - New schema: starts a new schema from scratch
  - View schema: the existing schema viewer has been moved into here
- Although this menu is exclusive for the demo, the logic of the saving/loading features mentioned above has been implemented and exported from formule as functions so they can be used in any project.
- The form key is now displayed in the SchemaPreview. It can be disabled with `hideSchemaKey`.
- The process of initializing the form has been simplified, now it's not needed to call `initFormuleSchema()` in a useEffect on first render anymore (you can still do it on demand or if you want to load an existing form).

Note: When loading a schema which contains an object field the demo can crash, requiring a reload. This will be worked on in https://github.com/cern-sis/react-formule/issues/88