### PR TITLE
feat(form): add steps component

### DIFF
--- a/formule-demo/cypress/e2e/builder.cy.ts
+++ b/formule-demo/cypress/e2e/builder.cy.ts
@@ -648,6 +648,34 @@ describe("test basic functionality", () => {
       .should("exist");
   });
 
+  it("tests steps field", () => {
+    cy.addFieldWithName("stepsView", "mysteps");
+    cy.getByDataCy("treeItem").contains("mysteps").as("stepsField");
+    cy.addFieldWithName("text", "myfield1", "@stepsField");
+    cy.addFieldWithName("text", "myfield2", "@stepsField");
+
+    // Direct navigation
+    cy.getByDataCy("formPreview")
+      .find(`input#root${SEP}mysteps${SEP}myfield1`)
+      .should("exist");
+    cy.getByDataCy("formPreview")
+      .find(".ant-steps-item")
+      .contains("myfield2")
+      .click();
+    cy.getByDataCy("formPreview")
+      .find(`input#root${SEP}mysteps${SEP}myfield2`)
+      .should("exist");
+    // Navigation with previous and next buttons
+    cy.getByDataCy("formPreview").find("button").contains("Previous").click();
+    cy.getByDataCy("formPreview")
+      .find(`input#root${SEP}mysteps${SEP}myfield1`)
+      .should("exist");
+    cy.getByDataCy("formPreview").find("button").contains("Next").click();
+    cy.getByDataCy("formPreview")
+      .find(`input#root${SEP}mysteps${SEP}myfield2`)
+      .should("exist");
+  });
+
   it("tests code editor field", () => {
     const shouldHaveValidationErrors = (point: boolean, range: boolean) => {
       if (!point && !range) {

--- a/formule-demo/src/App.tsx
+++ b/formule-demo/src/App.tsx
@@ -10,6 +10,7 @@ import {
   UploadOutlined,
   RollbackOutlined,
   ToolOutlined,
+  DownOutlined,
 } from "@ant-design/icons";
 import {
   Button,
@@ -326,7 +327,7 @@ function App() {
             <Row style={{ height: "100%" }}>
               <Col
                 xs={10}
-                sm={5}
+                md={5}
                 style={{
                   overflowX: "hidden",
                   height: "100%",
@@ -337,7 +338,7 @@ function App() {
               </Col>
               <Col
                 xs={14}
-                sm={5}
+                md={5}
                 style={{
                   overflowX: "hidden",
                   padding: "0px 15px",
@@ -348,7 +349,7 @@ function App() {
               </Col>
               <Col
                 xs={24}
-                sm={14}
+                md={14}
                 style={{
                   overflowX: "hidden",
                   height: "100%",
@@ -386,6 +387,7 @@ function App() {
           open={openFloatButtons}
           onClick={() => setOpenFloatButtons(!openFloatButtons)}
           icon={<ToolOutlined />}
+          closeIcon={<DownOutlined />}
           type="primary"
           badge={
             !openFloatButtons && hasUnsavedChanges

--- a/formule-demo/src/theme.ts
+++ b/formule-demo/src/theme.ts
@@ -13,5 +13,8 @@ export const theme = {
     Segmented: {
       trackBg: "#E4E8EC",
     },
+    Progress: {
+      defaultColor: PRIMARY_COLOR,
+    },
   },
 };

--- a/src/admin/utils/fieldTypes.jsx
+++ b/src/admin/utils/fieldTypes.jsx
@@ -1,14 +1,13 @@
 import {
   AimOutlined,
   AppstoreOutlined,
-  BookOutlined,
   BorderHorizontalOutlined,
   BorderTopOutlined,
   CalendarOutlined,
   CheckSquareOutlined,
   CloudDownloadOutlined,
   CodeOutlined,
-  ContainerOutlined,
+  AlignCenterOutlined,
   FontSizeOutlined,
   LayoutOutlined,
   LinkOutlined,
@@ -16,6 +15,9 @@ import {
   SwapOutlined,
   TagOutlined,
   UnorderedListOutlined,
+  FieldNumberOutlined,
+  FileMarkdownOutlined,
+  NodeIndexOutlined,
 } from "@ant-design/icons";
 import { placeholder } from "@codemirror/view";
 
@@ -54,6 +56,7 @@ export const common = {
             type: "boolean",
           },
         },
+        // Using dependencies here instead of if-then-else simplifies reusing the common properties
         dependencies: {
           showAsModal: {
             oneOf: [
@@ -317,6 +320,108 @@ const collections = {
       },
     },
   },
+  stepsView: {
+    title: "Steps",
+    icon: <NodeIndexOutlined />,
+    child: {},
+    optionsSchema: {
+      type: "object",
+      title: "Steps Field Schema",
+      properties: {
+        ...common.optionsSchema,
+      },
+    },
+    optionsSchemaUiSchema: {},
+    optionsUiSchema: {
+      ...common.optionsUiSchema,
+      type: "object",
+      title: "UI Schema",
+      properties: {
+        "ui:options": {
+          type: "object",
+          title: "UI Options",
+          dependencies:
+            common.optionsUiSchema.properties["ui:options"].dependencies,
+          properties: {
+            ...common.optionsUiSchema.properties["ui:options"].properties,
+            hideSteps: {
+              type: "boolean",
+              title: "Hide steps",
+              tooltip:
+                "Hide the steps and display a simple progress bar instead",
+            },
+          },
+          if: {
+            properties: {
+              hideSteps: {
+                const: false,
+              },
+            },
+          },
+          then: {
+            properties: {
+              stepsPlacement: {
+                type: "string",
+                title: "Steps placement",
+                oneOf: [
+                  { const: "horizontal", title: "Horizontal" },
+                  { const: "vertical", title: "Vertical" },
+                ],
+              },
+              hideButtons: {
+                type: "boolean",
+                title: "Hide buttons",
+                tooltip: "Hide the next and previous buttons",
+              },
+              hideNumbers: {
+                type: "boolean",
+                title: "Hide numbers",
+                tooltip: "Hide the step numbers and show a simple dot instead",
+              },
+              markAsCompleted: {
+                type: "boolean",
+                title: "Mark as completed",
+                tooltip:
+                  "Mark the steps as completed (if correct) after moving to the next one",
+              },
+            },
+          },
+        },
+        "ui:label": common.optionsUiSchema.properties["ui:label"],
+      },
+    },
+    optionsUiSchemaUiSchema: {
+      "ui:options": {
+        ...common.optionsUiSchemaUiSchema["ui:options"],
+        hideSteps: {
+          "ui:widget": "switch",
+        },
+        hideButtons: {
+          "ui:widget": "switch",
+        },
+        hideNumbers: {
+          "ui:widget": "switch",
+        },
+        markAsCompleted: {
+          "ui:widget": "switch",
+        },
+      },
+      "ui:label": common.optionsUiSchemaUiSchema["ui:label"],
+    },
+    default: {
+      schema: {
+        type: "object",
+        properties: {},
+      },
+      uiSchema: {
+        "ui:object": "stepsView",
+        "ui:options": {
+          stepsPlacement: "horizontal",
+          markAsCompleted: true,
+        },
+      },
+    },
+  },
   layerObjectField: {
     title: "Layer",
     icon: <BorderHorizontalOutlined />,
@@ -433,7 +538,7 @@ const simple = {
   },
   textarea: {
     title: "Text area",
-    icon: <ContainerOutlined />,
+    icon: <AlignCenterOutlined />,
     description: "Text Area field",
     child: {},
     optionsSchema: {
@@ -499,7 +604,7 @@ const simple = {
   },
   number: {
     title: "Number",
-    icon: <NumberOutlined />,
+    icon: <FieldNumberOutlined />,
     description: "IDs, order number, rating, quantity",
     child: {},
     optionsSchema: {
@@ -973,7 +1078,7 @@ const advanced = {
   },
   richeditor: {
     title: "Rich/LaTeX editor",
-    icon: <BookOutlined />,
+    icon: <FileMarkdownOutlined />,
     description: "Rich/LaTeX Editor Field",
     child: {},
     optionsSchema: {

--- a/src/forms/Form.less
+++ b/src/forms/Form.less
@@ -4,6 +4,7 @@
 .__Form__ {
   height: 100%;
   fieldset {
+    min-width: 0; // prevents overflow of antd Steps component
     border: 0;
   }
   label {
@@ -114,10 +115,6 @@
     display: none;
   }
 
-  .ant-select-dropdown .ant-select-item-option-content {
-    white-space: break-spaces;
-  }
-
   .formule-field-modal {
     .ant-modal-content .ant-modal-body {
       margin-top: 20px;
@@ -156,6 +153,13 @@
 
   .bounceShadow {
     animation: bounceShadow 5s forwards;
+  }
+
+  .ant-steps-item-icon {
+    border-radius: unset !important;
+    .ant-steps-icon {
+      font-weight: bold;
+    }
   }
 }
 

--- a/src/forms/templates/ObjectFieldTemplate.jsx
+++ b/src/forms/templates/ObjectFieldTemplate.jsx
@@ -6,6 +6,7 @@ import { PlusCircleOutlined } from "@ant-design/icons";
 import TabField from "./Tabs/TabField";
 import PropTypes from "prop-types";
 import FieldHeader from "./Field/FieldHeader";
+import StepsField from "./StepsField";
 
 const ObjectFieldTemplate = ({
   description,
@@ -80,6 +81,14 @@ const ObjectFieldTemplate = ({
   if (uiSchema["ui:object"] == "tabView")
     return (
       <TabField
+        uiSchema={uiSchema}
+        properties={properties}
+        idSchema={idSchema}
+      />
+    );
+  if (uiSchema["ui:object"] == "stepsView")
+    return (
+      <StepsField
         uiSchema={uiSchema}
         properties={properties}
         idSchema={idSchema}

--- a/src/forms/templates/StepsField.jsx
+++ b/src/forms/templates/StepsField.jsx
@@ -1,0 +1,168 @@
+import { Button, Col, Grid, Progress, Row, Steps, Typography } from "antd";
+import { _filterTabs, isFieldContainsError } from "./utils";
+import { useContext, useEffect, useRef, useState } from "react";
+import CustomizationContext from "../../contexts/CustomizationContext";
+
+const StepsField = ({ uiSchema, properties, idSchema }) => {
+  const options = uiSchema["ui:options"] || {};
+
+  const tabs = _filterTabs(options.tabs, options, properties);
+
+  const {
+    hideButtons,
+    hideSteps,
+    hideNumbers,
+    stepsPlacement,
+    markAsCompleted,
+  } = options;
+  const isVertical = stepsPlacement === "vertical";
+
+  const { useBreakpoint } = Grid;
+  const screens = useBreakpoint();
+  const customizationContext = useContext(CustomizationContext);
+  const [current, setCurrent] = useState(0);
+  const [anchor, setAnchor] = useState("");
+  const [scroll, setScroll] = useState(false);
+  const [progressColor, setProgressColor] = useState("");
+  const stepsRef = useRef(null);
+
+  window.addEventListener("hashchange", () => {
+    setAnchor(window.location.hash.replace("#", ""));
+  });
+
+  useEffect(() => {
+    if (window.location.hash) {
+      setAnchor(window.location.hash.replace("#", ""));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (anchor) {
+      const items = anchor.split(customizationContext.separator);
+      items.forEach((item, index) => {
+        if (idSchema.$id.includes(item)) {
+          const tabName = items[index + 1];
+          const activeIndex = tabs.findIndex((tab) => tab.name === tabName);
+          if (activeIndex > -1) {
+            setCurrent(activeIndex);
+            setScroll(true);
+          }
+        }
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor]);
+
+  useEffect(() => {
+    if (scroll) {
+      const elem = document.getElementById(anchor);
+      if (elem) {
+        setTimeout(() => {
+          elem.scrollIntoView({ behavior: "smooth" });
+        }, 500);
+      }
+    }
+  }, [current, anchor, scroll]);
+
+  useEffect(() => {
+    if (!hideSteps && !isVertical) {
+      // Horizontal scroll to the current step
+      stepsRef.current
+        .querySelector(".ant-steps-item-active")
+        ?.scrollIntoView({ behavior: "smooth" });
+    } else if (tabs.some((tab) => isFieldContainsError(tab))) {
+      setProgressColor("red");
+    } else {
+      setProgressColor("");
+    }
+  }, [current, hideSteps, isVertical, tabs]);
+
+  const items = tabs.map((tab, index) => ({
+    key: tab.name,
+    title: screens.md && (
+      <Typography.Paragraph
+        ellipsis={{ rows: 2, tooltip: { placement: "right" } }}
+      >
+        {tab.title || tab.content.props.schema.title || tab.name}
+      </Typography.Paragraph>
+    ),
+    status: isFieldContainsError(tab)
+      ? "error"
+      : !markAsCompleted && index != current && "wait",
+  }));
+
+  const updateCurrent = (value) => {
+    setCurrent(value);
+    setScroll(false);
+  };
+
+  const content = (
+    <Row style={{ width: "100%" }}>
+      <Col flex="auto">
+        <div>{tabs[current]?.content}</div>
+        {(!hideButtons || hideSteps) && (
+          <Row justify="space-between">
+            <Col>
+              {current > 0 && (
+                <Button onClick={() => updateCurrent(current - 1)}>
+                  Previous
+                </Button>
+              )}
+            </Col>
+            <Col>
+              {current < tabs.length - 1 && (
+                <Button
+                  type="primary"
+                  onClick={() => updateCurrent(current + 1)}
+                >
+                  Next
+                </Button>
+              )}
+            </Col>
+          </Row>
+        )}
+      </Col>
+    </Row>
+  );
+
+  return (
+    <>
+      {hideSteps ? (
+        <Progress
+          percent={(current / (items.length - 1)) * 100}
+          showInfo={false}
+          strokeLinecap="square"
+          style={{ marginBottom: "20px" }}
+          strokeColor={progressColor}
+        />
+      ) : (
+        <Row ref={stepsRef} gutter={20} wrap={false}>
+          <Col xs={isVertical && 8}>
+            <Steps
+              className="steps"
+              responsive={false}
+              labelPlacement={!isVertical && "vertical"}
+              progressDot={hideNumbers}
+              current={current}
+              direction={stepsPlacement}
+              onChange={updateCurrent}
+              items={items}
+              size="small"
+              style={
+                !isVertical && {
+                  overflowX: "scroll",
+                  padding: "10px",
+                  marginBottom: "10px",
+                }
+              }
+            />
+          </Col>
+          {isVertical && <Col flex="auto">{content}</Col>}
+        </Row>
+      )}
+      {(!isVertical || hideSteps) && content}
+    </>
+  );
+};
+
+export default StepsField;

--- a/src/forms/templates/Tabs/TabField.jsx
+++ b/src/forms/templates/Tabs/TabField.jsx
@@ -98,7 +98,7 @@ const TabField = ({ uiSchema, properties, idSchema }) => {
     if (scroll) {
       const elem = document.getElementById(anchor);
       if (elem) {
-        elem.scrollIntoView(true);
+        elem.scrollIntoView({ behavior: "smooth" });
       }
     }
   }, [activeTabContent, anchor, scroll]);


### PR DESCRIPTION
Closes #80 

Added steps component that allows creating wizard-style forms (or simply modular step sections inside of standard forms)  with several customization options:
* Vertical or horizontal
* Hide or show previous and next buttons
* Hide step numbers and show a progress bar instead
* Hide step numbers and show dots instead
* Mark previous steps as completed or not

Notes:
* Anchor links work seamlessly and will direct to the desired field in the appropriate step
* Steps with errors will be displayed in red (or the progress bar will take that color if any of them has errors)

<img width="400" alt="Screenshot 2024-12-10 at 18 25 57" src="https://github.com/user-attachments/assets/b4a782e3-6dd7-447a-aef6-27c5247e3fba">
<img width="400" alt="Screenshot 2024-12-10 at 18 26 08" src="https://github.com/user-attachments/assets/47aa9490-7d3e-4fa7-9792-48d18c5bf3b5">
<img width="400" alt="Screenshot 2024-12-10 at 18 26 19" src="https://github.com/user-attachments/assets/34fdefe0-8026-47ca-9a32-bfd0c9204f9e">
<img width="400" alt="Screenshot 2024-12-10 at 18 26 50" src="https://github.com/user-attachments/assets/7986cb85-1c14-41a1-a738-1851980db2f7">
