### PR TITLE
fix(form): add reload button to error boundary

### DIFF
--- a/src/forms/FormErrorBoundary.jsx
+++ b/src/forms/FormErrorBoundary.jsx
@@ -1,4 +1,5 @@
-import { Alert, Typography } from "antd";
+import { Alert, Button, Typography } from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
 
 const { ErrorBoundary } = Alert;
 
@@ -39,6 +40,13 @@ const FormErrorBoundary = ({ children }) => (
             </li>
           </ul>
         </Typography.Paragraph>
+        <Button
+          icon={<ReloadOutlined />}
+          onClick={() => window.location.reload()}
+          block
+        >
+          Reload page
+        </Button>
       </div>
     }
   >


### PR DESCRIPTION
Closes #93

* Adds a reload page button to error boundary
* Temporary "solution" to the SchemaTree update issue when loading schemas