### PR TITLE
fix(deps): add main declaration to package.json for bundlephobia

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
+  "main": "./dist/react-formule.umd.cjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Needed in order for Bundlephobia to work since it relies on `main` only instead of on `exports` (see https://github.com/pastelsky/bundlephobia/issues/379)