### PR TITLE
feat(form): show field description

### DIFF
--- a/formule-demo/src/App.tsx
+++ b/formule-demo/src/App.tsx
@@ -350,7 +350,7 @@ const App = () => {
                   value={JSON.stringify(
                     formuleState?.current.uiSchema,
                     null,
-                    2,
+                    2
                   )}
                   lang="json"
                   height="25vh"
@@ -434,7 +434,7 @@ const App = () => {
                       const reader = new FileReader();
                       reader.onload = (event) => {
                         const newSchema = JSON.parse(
-                          event?.target?.result as string,
+                          event?.target?.result as string
                         );
                         const { schema, uiSchema } = newSchema;
                         if (schema && uiSchema) {
@@ -443,7 +443,7 @@ const App = () => {
                           message.success("Uploaded and loaded successfully");
                         } else {
                           message.error(
-                            "Your json should include a schema and a uiSchema key",
+                            "Your json should include a schema and a uiSchema key"
                           );
                         }
                       };
@@ -528,7 +528,12 @@ const App = () => {
               )}
             />
           </Drawer>
-          <Content style={{ overflowY: "scroll" }}>
+          <Content
+            style={{
+              overflowY: "scroll",
+              scrollSnapType: screens.md ? "none" : "y mandatory",
+            }}
+          >
             <Row style={{ height: "100%" }}>
               <Col
                 xs={10}
@@ -537,6 +542,7 @@ const App = () => {
                   overflowX: "hidden",
                   height: "100%",
                   display: "flex",
+                  scrollSnapAlign: screens.md ? "none" : "start",
                 }}
               >
                 <SelectOrEdit />
@@ -548,6 +554,7 @@ const App = () => {
                   overflowX: "hidden",
                   padding: "0px 15px",
                   backgroundColor: "#F6F7F8",
+                  scrollSnapAlign: screens.md ? "none" : "start",
                 }}
               >
                 <SchemaPreview hideSchemaKey={false} />
@@ -555,7 +562,11 @@ const App = () => {
               <Col
                 xs={24}
                 md={14}
-                style={{ overflowX: "hidden", height: "100%" }}
+                style={{
+                  overflowX: "hidden",
+                  height: "100%",
+                  scrollSnapAlign: screens.md ? "none" : "start",
+                }}
               >
                 <FormPreview liveValidate={true} hideAnchors={false} />
               </Col>

--- a/src/admin/components/PropertyEditor.jsx
+++ b/src/admin/components/PropertyEditor.jsx
@@ -7,11 +7,12 @@ import {
   Popconfirm,
   Row,
   Space,
+  Tooltip,
   Typography,
 } from "antd";
 import { PageHeader } from "@ant-design/pro-layout";
 import Customize from "../components/Customize";
-import { DeleteOutlined } from "@ant-design/icons";
+import { DeleteOutlined, QuestionOutlined } from "@ant-design/icons";
 import { useDispatch, useSelector } from "react-redux";
 import {
   deleteByPath,
@@ -20,7 +21,7 @@ import {
 } from "../../store/schemaWizard";
 import CustomizationContext from "../../contexts/CustomizationContext";
 import { get } from "lodash-es";
-import { getIconByType } from "../utils";
+import { getFieldSpec } from "../utils";
 
 const { useBreakpoint } = Grid;
 
@@ -70,6 +71,12 @@ const PropertyEditor = () => {
 
   const dispatch = useDispatch();
 
+  const fieldSpec = getFieldSpec(
+    schema,
+    uiSchema,
+    customizationContext.allFieldTypes,
+  );
+
   useEffect(() => {
     if (path) {
       if (path.length) {
@@ -84,12 +91,39 @@ const PropertyEditor = () => {
 
   return (
     <div
-      style={{ display: "flex", flexDirection: "column", width: "100%" }}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        marginTop: "5px",
+      }}
       data-cy="fieldSettings"
     >
       <PageHeader
         onBack={() => dispatch(enableCreateMode())}
-        title={(screens.xl || path.length == 0) && "Field settings"}
+        title={
+          path.length == 0 ? (
+            "Root"
+          ) : (
+            <Space wrap={false}>
+              {screens.xl && fieldSpec.title}
+              <Tooltip
+                title={
+                  <>
+                    {!screens.xl && (
+                      <div style={{ fontWeight: "bold" }}>
+                        {fieldSpec.title}
+                      </div>
+                    )}
+                    <div>{fieldSpec.description}</div>
+                  </>
+                }
+              >
+                {fieldSpec.icon || <QuestionOutlined />}
+              </Tooltip>
+            </Space>
+          )
+        }
         extra={
           path.length > 0 && (
             <Popconfirm
@@ -102,7 +136,12 @@ const PropertyEditor = () => {
                 dispatch(enableCreateMode());
               }}
             >
-              <Button danger icon={<DeleteOutlined />} data-cy="deleteField" />
+              <Button
+                color="danger"
+                variant="text"
+                icon={<DeleteOutlined />}
+                data-cy="deleteField"
+              />
             </Popconfirm>
           )
         }
@@ -139,14 +178,7 @@ const PropertyEditor = () => {
             }
             style={{ textAlign: "center", margin: "10px 0" }}
           >
-            <Space wrap={false}>
-              {getIconByType(
-                schema,
-                uiSchema,
-                customizationContext.allFieldTypes,
-              )}
-              {name}
-            </Space>
+            <Space wrap={false}>{name}</Space>
           </Typography.Title>
         </Col>
       </Row>

--- a/src/admin/formComponents/SchemaTreeItem.jsx
+++ b/src/admin/formComponents/SchemaTreeItem.jsx
@@ -1,9 +1,14 @@
 import { useDispatch } from "react-redux";
 import { PropTypes } from "prop-types";
 
-import { DownOutlined, UpOutlined, CopyOutlined } from "@ant-design/icons";
+import {
+  DownOutlined,
+  UpOutlined,
+  CopyOutlined,
+  QuestionOutlined,
+} from "@ant-design/icons";
 import { Col, Dropdown, Row, Tag, Typography } from "antd";
-import { getIconByType, isItTheArrayField } from "../utils";
+import { getFieldSpec, isItTheArrayField } from "../utils";
 import { useContext } from "react";
 import CustomizationContext from "../../contexts/CustomizationContext";
 import { selectProperty } from "../../store/schemaWizard";
@@ -69,11 +74,8 @@ const SchemaTreeItem = ({
       >
         <Row gutter={8} onClick={handleClick} align="middle" wrap={false}>
           <Col flex="none">
-            {getIconByType(
-              schema,
-              uiSchema,
-              customizationContext.allFieldTypes,
-            )}
+            {getFieldSpec(schema, uiSchema, customizationContext.allFieldTypes)
+              .icon || <QuestionOutlined />}
           </Col>
           <Col flex="auto">
             <Row

--- a/src/admin/utils/fieldTypes.jsx
+++ b/src/admin/utils/fieldTypes.jsx
@@ -163,8 +163,8 @@ export const extra = {
 const collections = {
   object: {
     title: "Object",
-    icon: <span>&#123;&#32;&#125;</span>,
-    description: "Data in JSON format, Grouped section",
+    icon: <span>&#123;&nbsp;&#125;</span>,
+    description: "Group of fields, useful for nesting",
     className: "tour-object-field",
     child: {},
     optionsSchema: {
@@ -212,8 +212,7 @@ const collections = {
   array: {
     title: "List",
     icon: <UnorderedListOutlined />,
-    description:
-      "A list of things. List of strings, numbers, objects, references",
+    description: "List of fields supporting addition, deletion and reordering",
     className: "tour-list-field",
     child: {},
     optionsSchema: {
@@ -284,7 +283,7 @@ const collections = {
   accordion: {
     title: "Accordion",
     icon: <BorderTopOutlined />,
-    description: "A collapsible list of fields",
+    description: "List of collapsible fields",
     child: {},
     optionsSchema: {
       type: "object",
@@ -315,7 +314,7 @@ const collections = {
   layer: {
     title: "Layer",
     icon: <BorderHorizontalOutlined />,
-    description: "A list of modal fields",
+    description: "List of modal fields",
     child: {},
     optionsSchema: {
       type: "object",
@@ -346,7 +345,7 @@ const collections = {
   tabView: {
     title: "Tab",
     icon: <LayoutOutlined />,
-    description: "Data in JSON format, Grouped section",
+    description: "Group of fields separated in tabs",
     child: {},
     optionsSchema: {
       type: "object",
@@ -376,6 +375,7 @@ const collections = {
   },
   stepsView: {
     title: "Steps",
+    description: "Group of fields separated in steps",
     icon: <NodeIndexOutlined />,
     child: {},
     optionsSchema: {
@@ -484,7 +484,7 @@ const simple = {
   text: {
     title: "Text",
     icon: <FontSizeOutlined />,
-    description: "Titles, names, paragraphs, IDs, list of names",
+    description: "Text field supporting validation",
     className: "tour-text-field",
     child: {},
     optionsSchema: {
@@ -570,7 +570,7 @@ const simple = {
   textarea: {
     title: "Text area",
     icon: <AlignCenterOutlined />,
-    description: "Text Area field",
+    description: "Text area that can grow vertically",
     child: {},
     optionsSchema: {
       type: "object",
@@ -637,7 +637,7 @@ const simple = {
   number: {
     title: "Number",
     icon: <FieldNumberOutlined />,
-    description: "IDs, order number, rating, quantity",
+    description: "Number field (integer or float)",
     child: {},
     optionsSchema: {
       type: "object",
@@ -677,7 +677,8 @@ const simple = {
   checkbox: {
     title: "Checkbox",
     icon: <CheckSquareOutlined />,
-    description: "IDs, order number, rating, quantity",
+    description:
+      "Checkbox field with one or multiple options and customizable return values",
     child: {},
     optionsSchema: {
       type: "object",
@@ -723,7 +724,6 @@ const simple = {
                 items: {
                   title: "Define your options",
                   type: "object",
-                  description: "The options for the widget",
                   properties: {
                     enum: {
                       title: "Options List",
@@ -743,6 +743,13 @@ const simple = {
     },
     optionsSchemaUiSchema: {
       ...common.optionsSchemaUiSchema,
+      items: {
+        enum: {
+          items: {
+            "ui:label": false,
+          },
+        },
+      },
       readOnly: extra.optionsSchemaUiSchema.readOnly,
       isRequired: extra.optionsSchemaUiSchema.isRequired,
     },
@@ -769,7 +776,7 @@ const simple = {
   switch: {
     title: "Switch",
     icon: <SwapOutlined />,
-    description: "IDs, order number, rating, quantity",
+    description: "Switch field with customizable return types",
     child: {},
     optionsSchema: {
       type: "object",
@@ -832,7 +839,7 @@ const simple = {
   radio: {
     title: "Radio",
     icon: <AimOutlined />,
-    description: "IDs, order number, rating, quantity",
+    description: "Radio button with multiple options and only one selection",
     child: {},
     optionsSchema: {
       type: "object",
@@ -876,7 +883,7 @@ const simple = {
   select: {
     title: "Select",
     icon: <AppstoreOutlined />,
-    description: "IDs, order number, rating, quantity",
+    description: "Dropdown select with multiselect support",
     child: {},
     optionsSchema: {
       type: "object",
@@ -971,6 +978,13 @@ const simple = {
     },
     optionsSchemaUiSchema: {
       ...common.optionsSchemaUiSchema,
+      items: {
+        enum: {
+          items: {
+            "ui:label": false,
+          },
+        },
+      },
       readOnly: extra.optionsSchemaUiSchema.readOnly,
       isRequired: extra.optionsSchemaUiSchema.isRequired,
     },
@@ -993,7 +1007,8 @@ const simple = {
   date: {
     title: "Date",
     icon: <CalendarOutlined />,
-    description: "Date",
+    description:
+      "Date field with date and date-time support and date range validation",
     child: {},
     optionsSchema: {
       type: "object",
@@ -1065,7 +1080,7 @@ const advanced = {
   uri: {
     title: "URI",
     icon: <LinkOutlined />,
-    description: "Add uri text",
+    description: "URI/URL field with quick action buttons",
     child: {},
     optionsSchema: {
       type: "object",
@@ -1118,7 +1133,7 @@ const advanced = {
   richeditor: {
     title: "Rich/LaTeX editor",
     icon: <FileMarkdownOutlined />,
-    description: "Rich/LaTeX Editor Field",
+    description: "Interactive editor with support for LaTeX and Markdown",
     child: {},
     optionsSchema: {
       type: "object",
@@ -1152,7 +1167,7 @@ const advanced = {
   tags: {
     title: "Tags",
     icon: <TagOutlined />,
-    description: "Add keywords, tags, etc",
+    description: "List of tags with pattern validation",
     child: {},
     optionsSchema: {
       title: "Tags Schema",
@@ -1256,7 +1271,8 @@ const advanced = {
   codeEditor: {
     title: "Code Editor",
     icon: <CodeOutlined />,
-    description: "Code editor with syntax highlighting",
+    description:
+      "Code editor with syntax highlighting and JSONSchema validation",
     child: {},
     optionsSchema: {
       title: "Code Editor Schema",
@@ -1397,7 +1413,7 @@ const advanced = {
   file: {
     title: "Files",
     icon: <UploadOutlined />,
-    description: "Upload files",
+    description: "File upload with previews and extension whitelisting",
     child: {},
     optionsSchema: {
       type: "object",
@@ -1472,7 +1488,7 @@ export const hiddenFields = {
   integer: {
     title: "Integer",
     icon: <NumberOutlined />,
-    description: "IDs, order number, rating, quantity",
+    description: "Number field (integer or float)",
     child: {},
     optionsSchema: {
       type: "object",

--- a/src/admin/utils/index.jsx
+++ b/src/admin/utils/index.jsx
@@ -1,6 +1,4 @@
-import { QuestionOutlined } from "@ant-design/icons";
 import { hiddenFields } from "./fieldTypes";
-import { Tooltip } from "antd";
 
 export const SIZE_OPTIONS = {
   xsmall: 8,
@@ -54,7 +52,7 @@ export const combineFieldTypes = (fieldTypes, customFieldTypes) => {
 
 export const timer = (ms) => new Promise((res) => setTimeout(res, ms));
 
-export const getIconByType = (schema, uiSchema, fieldTypes) => {
+export const getFieldSpec = (schema, uiSchema, fieldTypes) => {
   let type = "unknown";
   // in case we can not define the type of the element from the uiSchema,
   // extract the type from the schema
@@ -91,9 +89,8 @@ export const getIconByType = (schema, uiSchema, fieldTypes) => {
       fieldTypesWithHidden[category].fields,
     )) {
       if (key === type) {
-        return <Tooltip title={value.title}>{value.icon}</Tooltip>;
+        return value;
       }
     }
   }
-  return <QuestionOutlined />;
 };


### PR DESCRIPTION
Closes #109 

- Shows field type name and icon with a tooltip containing its description. Changed some descriptions to make them more correct.
- Hiding array item titles for checkbox and select options
- Adding snap scroll **in mobile** from field types and schema tree to form preview below