### PR TITLE
ci(demo): fix manual demo deployment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-deploy-demo:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     name: Build and deploy demo
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Manual trigger for demo deployment was not working since it relied on previous work (publish) success, which in such scenario is null